### PR TITLE
Corrected short and long range checks

### DIFF
--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -274,6 +274,18 @@ class TestFileTiffMetadata(PillowTestCase):
         self.assertEqual(numerator, reloaded.tag_v2[37380].numerator)
         self.assertEqual(denominator, reloaded.tag_v2[37380].denominator)
 
+    def test_ifd_signed_long(self):
+        im = hopper()
+        info = TiffImagePlugin.ImageFileDirectory_v2()
+
+        info[37000] = -60000
+
+        out = self.tempfile("temp.tiff")
+        im.save(out, tiffinfo=info, compression="raw")
+
+        reloaded = Image.open(out)
+        self.assertEqual(reloaded.tag_v2[37000], -60000)
+
     def test_expty_values(self):
         data = io.BytesIO(
             b"II*\x00\x08\x00\x00\x00\x03\x00\x1a\x01\x05\x00\x00\x00\x00\x00"

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -575,12 +575,10 @@ class ImageFileDirectory_v2(MutableMapping):
                         else TiffTags.SIGNED_RATIONAL
                     )
                 elif all(isinstance(v, int) for v in values):
-                    if all(v < 2 ** 16 for v in values):
-                        self.tagtype[tag] = (
-                            TiffTags.SHORT
-                            if all(v >= 0 for v in values)
-                            else TiffTags.SIGNED_SHORT
-                        )
+                    if all(0 <= v < 2 ** 16 for v in values):
+                        self.tagtype[tag] = TiffTags.SHORT
+                    elif all(-2 ** 15 < v < 2 ** 15 for v in values):
+                        self.tagtype[tag] = TiffTags.SIGNED_SHORT
                     else:
                         self.tagtype[tag] = (
                             TiffTags.LONG


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/3980

There is a line that determines if a tag is a short/signed short, rather than a long/signed long - `if all(v < 2 ** 16 for v in values):`. It is not that simple, as that line only considers the max value, not the min value.